### PR TITLE
Branch Guard workflow: post-hoc detect direct pushes to main

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,50 @@
+name: Branch Guard (main)
+
+# Post-hoc detection of direct pushes to main. The push has already landed
+# by the time this runs — this is doctrine reinforcement, not a hard gate.
+# (GitHub's hard-block branch protection requires Pro for private repos.)
+#
+# A "direct push" = any push to main whose head commit is not associated
+# with a merged PR via /repos/{owner}/{repo}/commits/{sha}/pulls.
+#
+# Squash merges, merge commits, and rebase merges from gh/UI all attach
+# their PR via the GitHub API — they pass. Anything else fails the check
+# and surfaces in the Actions tab as a doctrine violation.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify push originated from a merged PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          SHA="${{ github.sha }}"
+          REPO="${{ github.repository }}"
+          echo "Checking commit $SHA on $REPO ..."
+
+          PR_COUNT=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq 'length')
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "::error::Direct push to main detected (commit $SHA has no associated PR)."
+            echo "::error::All changes to main must go through a PR per CLAUDE.md doctrine."
+            echo "::error::See: https://github.com/$REPO/blob/main/CLAUDE.md#the-council-is-the-audit-gate"
+            exit 1
+          fi
+
+          MERGED_COUNT=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '[.[] | select(.merged_at != null)] | length')
+          if [ "$MERGED_COUNT" -eq 0 ]; then
+            echo "::error::Commit $SHA is referenced by PR(s) but none are marked merged."
+            echo "::error::This is unexpected on main; investigate manually."
+            exit 1
+          fi
+
+          PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '[.[] | select(.merged_at != null)][0].number')
+          echo "✓ Commit $SHA is the merge of PR #$PR_NUM — branch guard passes."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,15 @@ Follow a TDD-style cadence for code changes. The council runs once per push to P
 
 ## Firestore discipline
 
+**Before any manual pipeline run that writes to production Firestore** (`research_city.py --ingest`, `enrich_ingest.ts`, `build_cache.ts`, etc.) verify that `.github/workflows/branch-guard.yml` is **green on the HEAD commit of `main`** that you're running from. This closes the manual-run loophole the auto-deploy guard doesn't cover: if someone direct-pushed an unreviewed change to `main` and the guard failed post-hoc, running the pipeline from that HEAD propagates the unreviewed code to production data. Quick check:
+
+```bash
+gh run list --workflow branch-guard.yml --branch main --limit 1 --json conclusion --jq '.[0].conclusion'
+# expect: "success"
+```
+
+If it returns anything else, sync to a known-good commit before running.
+
 - GCP project: `urban-explorer-483600`. Named database: `urbanexplorer` (the rename to `travel-cities` was planned but not executed; code in `enrich_ingest.ts:25`, `build_cache.ts:601,1073`, `qc_cleanup.ts:26`, `backfill_task_neighborhoods.ts:30`, `firestore/admin.ts:20` all point at `urbanexplorer`. Edit any `travel-cities` references out as found, or land the rename and the doctrine together.)
 - Pipeline writes (verified against code):
   - `cities/{cityId}` — top-level city metadata

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,11 @@ This is the pipeline repo. It produces the shared city atlas that Urban Explorer
 
 Every change to `main` goes through a PR. `.github/workflows/council.yml` runs a 7-persona Gemini review (architecture, cost, bugs, security, product, accessibility, lead-architect-synthesis) on every PR open + push. The Lead Architect synthesis posts a single re-editable PR comment with a verdict: 🟢 CLEAR | 🟡 CONDITIONAL | 🔴 BLOCK.
 
-**Direct pushes to `main` are flagged by `.github/workflows/branch-guard.yml`** — a post-hoc detector that fails on any push to `main` whose head commit is not associated with a merged PR. The push has already landed by the time the workflow runs; this is doctrine reinforcement plus an Actions-tab paper trail, not a hard gate. (GitHub's hard-block branch protection requires Pro for private repos; revisit if the repo goes public or the team upgrades.) Squash-merges, merge commits, and rebase-merges via `gh pr merge` or the GitHub UI all pass — they attach their PR via the GitHub API. Direct `git push` from a workstation fails the check.
+**Direct pushes to `main` are flagged by `.github/workflows/branch-guard.yml`** — a post-hoc detector that fails on any push to `main` whose head commit is not associated with a merged PR.
+
+**This is detection, not prevention.** The push has *already landed* when the workflow runs. If a downstream consumer (UE, Roadtripper) is auto-deploying off `main`, an offending direct push could ship to production before the guard fires. **Mitigated today by the absence of any auto-deploy from this repo** — the pipeline is run manually, not on `main` push — but if a deploy hook is ever added, the same "from merged PR" check must be incorporated as the deploy's mandatory first step. Squash-merges, merge commits, and rebase-merges via `gh pr merge` or the GitHub UI all pass — they attach their PR via the GitHub API. Direct `git push` from a workstation fails the check.
+
+GitHub's hard-block branch protection (the preventative equivalent) requires Pro for private repos; revisit if the repo goes public or the team upgrades. Until then, the soft fence + doctrine + Actions-tab paper trail is the bar.
 
 **Default: you cannot merge without a 🟢.** CONDITIONAL = address the remediations in a follow-up commit; council auto-reruns. BLOCK = rethink the change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This is the pipeline repo. It produces the shared city atlas that Urban Explorer
 
 Every change to `main` goes through a PR. `.github/workflows/council.yml` runs a 7-persona Gemini review (architecture, cost, bugs, security, product, accessibility, lead-architect-synthesis) on every PR open + push. The Lead Architect synthesis posts a single re-editable PR comment with a verdict: 🟢 CLEAR | 🟡 CONDITIONAL | 🔴 BLOCK.
 
-**Direct pushes to `main` are blocked by GitHub branch protection** (configured 2026-04-26 alongside this doctrine). The workflow itself only fires on `pull_request` events, so without protection a direct push would silently bypass the gate. The protection closes that gap; without it, the doctrine is aspirational.
+**Direct pushes to `main` are flagged by `.github/workflows/branch-guard.yml`** — a post-hoc detector that fails on any push to `main` whose head commit is not associated with a merged PR. The push has already landed by the time the workflow runs; this is doctrine reinforcement plus an Actions-tab paper trail, not a hard gate. (GitHub's hard-block branch protection requires Pro for private repos; revisit if the repo goes public or the team upgrades.) Squash-merges, merge commits, and rebase-merges via `gh pr merge` or the GitHub UI all pass — they attach their PR via the GitHub API. Direct `git push` from a workstation fails the check.
 
 **Default: you cannot merge without a 🟢.** CONDITIONAL = address the remediations in a follow-up commit; council auto-reruns. BLOCK = rethink the change.
 


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/branch-guard.yml\` — a post-hoc detector that fails on any direct push to \`main\`. Updates CLAUDE.md to describe what actually exists (the workflow), not the aspirational branch-protection that requires GitHub Pro for private repos.

## Why this shape

Branch protection in PR #19's plan was rejected by GitHub: free-tier private repos can't enable it. Three alternatives discussed:
- **Make repo public** — gets free branch protection; out of scope for this PR.
- **Upgrade to GitHub Pro** — \$4/mo; out of band.
- **Workflow-based soft enforcement** ← this PR.

Soft enforcement catches the realistic failure mode (me or a future operator running \`git push origin main\` out of habit during a session-close, like \`87af222\` this session) without costing anything or making the repo public. It's doctrine reinforcement with an Actions-tab paper trail, not a hard gate.

## How it works

\`\`\`
on: push: branches: [main]
\`\`\`

For each push, calls \`gh api /repos/{owner}/{repo}/commits/{sha}/pulls\`. The endpoint returns associated PRs for any commit on main:
- Squash-merges, merge commits, rebase-merges via \`gh pr merge\` / GitHub UI → returns the PR with \`merged_at\` set → ✓ pass.
- Direct \`git push\` from a workstation → empty array → ✗ fail with a CLAUDE.md link.

Verified against \`c9f8985\` (PR #19's squash commit): API returned 1 PR (#19) with \`merged_at = 2026-04-25T23:33:45Z\`. Detection works.

## Limitations (intentional)

- **Post-hoc, not blocking.** The push has already landed when the workflow runs. To get a hard pre-receive block, GitHub Pro or a public repo is required.
- **Bypass-able by disabling the workflow.** A determined contributor could disable \`branch-guard.yml\` itself, then push, then re-enable. Mitigated by: this is a solo-contributor repo, the doctrine is on record in CLAUDE.md, and \`.github/workflows/\` changes are themselves PR-gated by the council (which reviews this very directory in its required-checks list).

## Test plan
- [x] Workflow syntax valid (matches \`pr-watch.yml\` shape).
- [x] Detection logic verified against a real squash-merge SHA (PR #19).
- [ ] Council 🟢 (markdown + small workflow file).
- [ ] After merge: this PR's own merge will exercise the new workflow on its first run; expect ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)