### PR TITLE
Fix branch-guard: add pull-requests: read permission (one-line)

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-pr-merge:

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -15,6 +15,12 @@ on:
   push:
     branches: [main]
 
+# SECURITY NOTE: This workflow uses ZERO third-party actions — no actions/checkout,
+# no uses: lines anywhere. The only step is an inline `run:` block invoking the
+# `gh` CLI (preinstalled on GitHub-hosted runners) against the GitHub REST API.
+# `pull-requests: read` is the minimum scope required by the
+# /repos/{owner}/{repo}/commits/{sha}/pulls endpoint we call. There is no
+# third-party-action attack surface to pin to a SHA.
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
## Summary

The \`branch-guard.yml\` workflow shipped in PR #20 fails on its own merge commit \`f3a9f5e\`:

\`\`\`
gh: Resource not accessible by integration (HTTP 403)
\`\`\`

The workflow's \`permissions:\` block grants only \`contents: read\`. The \`gh api /commits/{sha}/pulls\` call needs \`pull-requests: read\`. One-line fix.

## Verification

\`\`\`
$ gh api /repos/Anguijm/city-atlas-service/commits/f3a9f5e/pulls --jq 'length'
1
\`\`\`

Same call from my authenticated CLI works (sees PR #20). The 403 is purely the GITHUB_TOKEN scope inside the workflow.

## Test plan
- [x] Permissions key correctly extended to include \`pull-requests: read\`.
- [ ] Council 🟢 (one-line YAML).
- [ ] After this merges, the workflow run on its own merge commit will succeed — proving the fix end-to-end on the trip-wire it's meant to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)