### PR TITLE
Session close 2026-04-26 (continued): docs refresh after PR #19/#20/#22

### DIFF
--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -618,3 +618,83 @@ Immediately after the validation block above closed, kicked off `--ingest-only -
 3. **#12 — CI smoke-test on entry-point scripts.** Three porting-miss bugs landed in this session's prior cohort; pattern is now well-established. Filing earned three data points.
 4. **#17 — unit tests for `geoBoundsFor` + Infatuation HTML fixtures.** Round-2 #4 ask, deferred. Cheap follow-up.
 5. **Geneva + lisbon language-aware Phase A** remains parked. Probably wants its own issue if it surfaces again.
+
+---
+
+## 2026-04-26 (continued) — doctrine reconciliation + branch-guard saga
+
+`main` HEAD: `942dc50` (PR #22 squash-merge). Started this continuation at `87af222`.
+Three PRs landed: **#19 (`c9f8985`)**, **#20 (`f3a9f5e`)**, **#22 (`942dc50`)**.
+Two issues filed: **#21**, **#23**.
+
+### KEEP
+
+- **Audit doctrine vs code BEFORE drafting anything that depends on either.** When the user asked for a Roadtripper-integration prompt, my first draft used CLAUDE.md's stated DB name `travel-cities` and schema package `@travel/city-atlas-types`. Both wrong. Code says `urbanexplorer` (six call sites: `enrich_ingest.ts:25`, `build_cache.ts:601,1073`, `qc_cleanup.ts:26`, `backfill_task_neighborhoods.ts:30`, `firestore/admin.ts:20`); package.json says `"name": "city-atlas-service"`, no separate package. **Generalization: when the user asks "give me a prompt to feed elsewhere," verify the load-bearing facts against the code first, not the docs.** Docs decay; code is what runs.
+
+- **Branch-guard via workflow-on-push is the right "soft fence" for free-tier private repos.** GitHub branch protection requires Pro for private repos (or making the repo public). `.github/workflows/branch-guard.yml` calls `gh api /repos/{owner}/{repo}/commits/{sha}/pulls` and fails the run when the head commit has no associated merged PR. It's post-hoc detection (push has already landed), but it's free, leaves an Actions-tab paper trail on every direct push, and would have caught my session-close direct-commit `87af222` immediately. **Verified end-to-end** on PR #22's merge commit `942dc50` — workflow ran in 9s, found PR #22 in the API response, exited green.
+
+- **Council on a "self-test" markdown PR shape is the validation** that the council still works on small clean diffs even while the synthesizer has known drift problems on substantive ones. PR #18 (CLAUDE.md doctrine update) and PR #19 (doctrine + reality reconciliation, CONDITIONAL with one comment-fulfilled remediation) both demonstrated the council producing clean signal on tight scoped diffs. Useful canary.
+
+- **The submitter response comment format codified in PR #18 is paying dividends already.** Used on PR #19 (round 1 → admin override), PR #20 (round 1 → R2 → R3), PR #22 (round 1 → R2). Every PR's response comment mapped each remediation to status (✅ addressed / 🚫 OOS) with a specific reason per OOS item. The format makes both council re-runs AND admin-override paperwork obvious-by-construction.
+
+### IMPROVE
+
+- **Doctrine and code MUST agree.** Three load-bearing CLAUDE.md claims were directly contradicted by code: DB name (`travel-cities` doc / `urbanexplorer` code), package name (`@travel/city-atlas-types` doc / no package), per-app collections (`tasks_rt`/`tasks_ue` doc / nested + `vibe_tasks` code). All three were aspirational descriptions of a planned state, not a current state. **They caused real friction this session** (wrong DB name surfaced when drafting the Roadtripper prompt; user caught it mid-thread). The lesson is structural: **when CLAUDE.md describes a planned migration that hasn't shipped, label it explicitly as planned-but-not-executed**, not as the current state. The new doctrine wording uses this pattern: "the rename to travel-cities was planned but not executed; edit travel-cities references out as found, or land the rename and the doctrine together."
+
+- **The workflow trigger gap was undetectable from CLAUDE.md alone.** `council.yml` fires on `pull_request` events only, so direct pushes silently bypass. CLAUDE.md said "Every merge to main is gated" — true if "merge" means "PR merge"; false if "merge" includes "git push." User caught it by asking the right question: *"did the session close updates need to be sent thru council? were they?"* **Generalization: if doctrine claims an enforcement, verify the enforcement exists at the layer claimed (workflow trigger, branch protection, hook), not just the layer assumed.**
+
+- **Council synthesizer drift is now a multi-instance pattern with clear shape.** Documented examples within this repo:
+  - **PR #15** (R1 → R2): three-surface flip (log→throw, +15km approve→reject, reinstate→remove `places[]`).
+  - **PR #20** (R2 → R3): same-surface flip on manual-vs-automated preflight check.
+  - **PR #22** (R1 → R2): scoring-rule misfire — cost=1+product=2+empty bodies → 🟢 on PR #18 last week, → 🔴 on PR #22 this round. Different verdicts on identical scoring shapes.
+  
+  All three are now load-bearing evidence for **#16 (cross-round memory)** and **#23 (lead-architect rule tightening)**. Both should be tackled before the next substantive PR.
+
+- **My own session-close commit `87af222` was a doctrine violation.** Direct push to main, bypassed council entirely, surfaced when the user asked. The new doctrine plus branch-guard make this exact mistake catchable next time. **Audit-vs-action lesson: when the user invokes a session-close prompt, the prompt itself does not specify the merge mechanism. The repo's doctrine has to enforce it; the prompt stays general.** The fix here was to add branch-guard so future direct-push attempts fail loudly even if I forget the rule.
+
+### INSIGHT
+
+- **Squash-merge commits ARE associated with their PR via the GitHub API**, even though the SHA is unique to main. `gh api /repos/{owner}/{repo}/commits/{sha}/pulls` returns the source PR with `merged_at` populated. This is what makes the branch-guard workflow tractable — there's no need for commit-message parsing, signature checking, or other heuristics. The API is the source of truth.
+
+- **GITHUB_TOKEN's default permissions in workflows are minimal; `pull-requests: read` is required for the `/commits/{sha}/pulls` endpoint.** Default scope from `permissions: contents: read` returns 403 on that endpoint. Found by running PR #20's workflow on its own merge commit and watching it fail. **Lesson: when adding a workflow that calls anything outside `contents:`, audit the token-scope explicitly.** GitHub's docs on `GITHUB_TOKEN` scopes are necessary reading for any new workflow.
+
+- **The `--admin` flag on `gh pr merge` requires explicit `--subject` and `--body` to set the squash-commit message.** Without them, admin merge pulls from the PR title/body but sometimes doesn't fully populate the commit message — verified by reading the resulting commit. Worth knowing for the next override.
+
+- **The council's lead-architect "any reviewer ≤4 → BLOCK" rule is overly broad.** It conflates "this axis has concerns" with "this axis is irrelevant to the diff." Cost and product reviewers correctly score 1-2 when a markdown / YAML / CI-config diff has zero impact on their slice — but the synthesizer rule then fires BLOCK on score noise. Filed as **#23**. The proposed fix is to require BOTH score ≤4 AND a non-empty concern body before triggering BLOCK; alternative is to recalibrate the cost/product personas to score 10 (no concern) when the axis isn't applicable, mirroring how accessibility scores 10 on every non-UI diff.
+
+- **Branch-guard exposes a chicken-and-egg on direct-fixing the workflow itself.** When the workflow shipped broken (`f3a9f5e` failed because of token-scope bug), I couldn't direct-push the fix to main — branch-guard would itself fail post-hoc, and the doctrine forbids it anyway. PR-only path for the fix (PR #22) is correct AND structural: *the only way to fix the broken trip-wire was to use the trip-wire's intended channel.* That's a useful self-test.
+
+### COUNCIL
+
+- **PR #19 (doctrine + reconciliation): R1 🟡 CONDITIONAL** with one remediation: "Add a PR comment with permalinks verifying the nested `tasks` subcollection claim." Remediation type was "PR Comment / PR Author" — fulfilled by https://github.com/Anguijm/city-atlas-service/pull/19#issuecomment-4320808422 (5 permalinks: `enrich_ingest.ts:237-242`, `enrich_ingest.ts:233`, `build_cache.ts:706-712`, `firestore.rules:35`, plus the negative grep). **Admin-merged** because the council can't auto-rerun on a PR comment, and a no-op-commit re-trigger would burn ~7 Gemini calls to confirm a comment the synthesizer accepted as the response shape.
+
+- **PR #20 (branch-guard workflow): R1 🔴 → R2 🟡 → R3 🔴.** Score progression:
+  ```
+                  R1   R2   R3
+  accessibility   10   10   10
+  architecture    10    8    9
+  bugs             3   10    7
+  cost            10   10    1
+  product          9    9    9
+  security         4    9    4
+  ```
+  R2 prescribed "add a manual preflight check in CLAUDE.md." Implemented in `880043d` exactly as prescribed. R3 prescribed "manual preflight is unacceptable, automate the check inside pipeline entry points." Direct contradiction on the same surface. **Admin-overridden** per the round-N drift doctrine landed in PR #18. Filed **#21** for the legitimate automation work with full implementation sketch.
+
+- **PR #22 (permissions one-liner): R1 🔴 → R2 🔴.** R1 security at 4 hallucinated a third-party-action attack surface that doesn't exist (workflow has zero `uses:` lines). Addressed by adding a SECURITY NOTE comment to the YAML stating the no-attack-surface guarantee directly. R2 went 🔴 again on cost=1+product=2 with empty bodies — the **synthesizer scoring-rule misfire** filed as #23. **Admin-overridden** with rationale citing the inconsistency vs PR #18 R1 (same scores 1+2, verdict 🟢).
+
+- **Net council burn this turn: 7 Gemini-council runs across 3 merged PRs, 3 of which were admin-override-justified non-substantive blocks.** PR #19 burned 1 round; PR #20 burned 3 rounds; PR #22 burned 2 rounds; the doctrine PR (#18) from earlier this session burned 1 round 🟢. Without admin override on the same-surface flips and scoring-rule misfires, this turn would have burned 3-4 more rounds before convergence (or never converged). **The doctrine is paying for itself.**
+
+### Production state at session close (continued)
+- `main`: `942dc50` (PR #22).
+- Open PRs: **session-close PR pending** (this very commit; will be PR #24).
+- Open issues: **9 total** — #5, #6, #7, #8, #9, #12, #14, #16, #17, #21, #23 (added #21 + #23 this turn). PR #11 closed by #15 prior turn; #10 closed in earlier session via `f627d83`.
+- Production Firestore unchanged: still 15/16 metros from the parked-19, honolulu still pending one-step recovery, geneva + lisbon still parked, london still missing from manifest.
+- Branch-guard workflow live and verified (`942dc50` itself triggered + passed it on merge).
+
+### Carryover for next session (re-prioritized)
+
+1. **#16 + #23 — council-tightening sprint.** These two together are the highest-leverage work on the bench. #16 closes cross-round memory (the structural cause of same-surface drift). #23 tightens the `≤4 → BLOCK` rule (the structural cause of empty-body scoring noise blocking PRs). Together they prevent the ~3 wasted rounds per substantive PR currently being absorbed. ~80–120 lines of code total + a .harness/council/lead-architect.md rule edit.
+2. **#21 — automate branch-guard preflight inside pipeline entry points.** The legitimate ask from PR #20 R3, deferred. Pure defense-in-depth on production writes; not blocking.
+3. **Honolulu recovery** — still one-step. `mv data/research-output/failed/honolulu.json data/research-output/honolulu.json && python src/pipeline/research_city.py --city honolulu --ingest-only --enrich`. Closes 15/16 → 16/16.
+4. **#12 — CI smoke-test on entry-point scripts.** Three-data-points porting-miss bug class, still relevant.
+5. **#17 — unit tests for `geoBoundsFor` + Infatuation HTML fixtures.** Cheap follow-up from PR #15 R2.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,16 +4,17 @@
 > For long-form session learnings see `.harness/learnings.md`.
 > For start-here-next-session block see `SESSION_HANDOFF.md`.
 >
-> Last refreshed: 2026-04-26.
+> Last refreshed: 2026-04-26 (continued).
 
 ## Now (this week)
 
-- **Council infra fix** — Extend `.harness/scripts/council.py` to fetch prior council comment + submitter response and prepend to round-N persona prompts. Eliminates the override-paperwork tax on substantive PRs. ([#16](https://github.com/Anguijm/city-atlas-service/issues/16))
+- **Council-tightening sprint: #16 + #23 together.** Same root cause family: the council can't prevent itself from drifting because it has no cross-round memory (#16) AND the lead-architect rule fires BLOCK on score noise from no-impact axes (#23). PR #20 burned 3 rounds and PR #22 burned 2 rounds this turn for non-substantive reasons that these two fixes specifically address. ~80–120 lines combined. ([#16](https://github.com/Anguijm/city-atlas-service/issues/16), [#23](https://github.com/Anguijm/city-atlas-service/issues/23))
 - **Honolulu recovery** — `mv data/research-output/failed/honolulu.json data/research-output/honolulu.json && python src/pipeline/research_city.py --city honolulu --ingest-only --enrich`. Closes 15/16 → 16/16 on the 2026-04-08 parked-metros backlog. (no issue; one-step manual op)
-- **CI smoke-test on entry-point scripts** — Three porting-miss bugs landed in prior sessions (`90b8c2a`, `f627d83`, `1f173b7`); pattern is well-established. File-and-design before the next porting cycle introduces a fourth. ([#12](https://github.com/Anguijm/city-atlas-service/issues/12))
+- **Automate branch-guard preflight inside pipeline entry points** — Round-3 council ask on PR #20, deferred. Real defense-in-depth on production writes; the manual preflight in CLAUDE.md is fallible. Helper called from each `--ingest`/`--ingest-only` entry point that refuses to run if branch-guard isn't green on HEAD. ([#21](https://github.com/Anguijm/city-atlas-service/issues/21))
 
 ## Next (queued, scoped)
 
+- **CI smoke-test on entry-point scripts** — Three porting-miss bugs landed in prior sessions (`90b8c2a`, `f627d83`, `1f173b7`); pattern is well-established. File-and-design before the next porting cycle introduces a fourth. ([#12](https://github.com/Anguijm/city-atlas-service/issues/12))
 - **Unit tests for `geoBoundsFor` + Infatuation HTML fixtures** — Round-2 council ask on PR #15, deferred. Pure-function test + 3 captured HTML states (success, no-results, error). ([#17](https://github.com/Anguijm/city-atlas-service/issues/17))
 - **Phase A prompt-injection markers** — Wrap scraped content in boundary markers across all 6 scraper outputs (not partial); meta-prompt instruction to treat as untrusted. Council reviewers re-raise this every PR that touches scrapers. ([#7](https://github.com/Anguijm/city-atlas-service/issues/7))
 - **Tier-aware deletion floor** — Phase C threshold currently uses a single proportional `>25%` rule; village-tier cities with small audit samples get unfair rejections. ([#6](https://github.com/Anguijm/city-atlas-service/issues/6))
@@ -24,9 +25,11 @@
 ## Someday (architecture / daydreams)
 
 - **Admin web interface for POI find/add/edit** — Paste-URL-or-info to add or correct waypoints without re-running the pipeline. Backend writes with `source: "admin-manual"` parallel to `enrichment-*`. Force-multiplier once the bulk-ingest backlog is cleared. ([#14](https://github.com/Anguijm/city-atlas-service/issues/14))
+- **Land the `urbanexplorer` → `travel-cities` rename** — Six call sites (`enrich_ingest.ts:25`, `build_cache.ts:601,1073`, `qc_cleanup.ts:26`, `backfill_task_neighborhoods.ts:30`, `firestore/admin.ts:20`) plus a Firestore named-database migration. Currently the doctrine acknowledges the rename was planned-but-not-executed; either land it or stop calling it planned. (no issue yet)
+- **GitHub Pro for hard branch protection** — Branch-guard is post-hoc detection; Pro ($4/mo) or making the repo public would enable preventative branch protection. Revisit if a second contributor joins or if `942dc50`-style direct-push paper trails accumulate. (no issue)
 - **Language-aware Phase A** — Geneva + Lisbon failed Phase C because English-only sources are thin; Phase B fabricates over the gap. Either a `--language` flag in Phase A's prompt, or non-English source scrapers (French Wikipedia for Geneva, Portuguese Reddit for Lisbon). No issue yet; would be filed when actively scoped.
 - **London manifest mystery** — London is in `configs/global_city_cache.json` but absent from `manifest.cities`. Quick-cause-finder wasn't done; low priority while everything else works.
-- **Persona prompt strengthening** — Several round-2 council asks have been "verify X" where the reviewer could verify themselves (`jq` over the city cache answers most of these). Tighten persona prompts to "check yourself, then ask only if there's a problem." Layer 3 of the council-tightening plan after #16.
+- **Persona prompt strengthening** — Several round-2 council asks have been "verify X" where the reviewer could verify themselves (`jq` over the city cache answers most of these). Tighten persona prompts to "check yourself, then ask only if there's a problem." Layer 3 of the council-tightening plan after #16 + #23.
 
 ## Open issues (mirror of `gh issue list --state open`)
 
@@ -39,15 +42,20 @@
 | [#9](https://github.com/Anguijm/city-atlas-service/issues/9) | Security: replace personal email with role-based address in scraper User-Agents | Info-disclosure hygiene. |
 | [#12](https://github.com/Anguijm/city-atlas-service/issues/12) | CI smoke-test on entry-point scripts to catch porting-miss bugs at port time | Three-data-points bug class; CI prevention earned. |
 | [#14](https://github.com/Anguijm/city-atlas-service/issues/14) | Admin web interface: find/add/edit POIs by URL or pasted info | UE/Roadtripper-adjacent admin tool; not blocking. |
-| [#16](https://github.com/Anguijm/city-atlas-service/issues/16) | Council infrastructure: pass prior remediations + submitter response into round-N prompt | Highest-leverage council fix; ~50–80 lines in `council.py`. |
+| [#16](https://github.com/Anguijm/city-atlas-service/issues/16) | Council infrastructure: pass prior remediations + submitter response into round-N prompt | Highest-leverage council fix; ~50–80 lines in `council.py`. Pair with #23. |
 | [#17](https://github.com/Anguijm/city-atlas-service/issues/17) | Unit tests for geoBoundsFor + Infatuation scraper fixtures | Round-2 #4 on PR #15, deferred follow-up. |
+| [#21](https://github.com/Anguijm/city-atlas-service/issues/21) | Automate branch-guard preflight inside pipeline entry points | PR #20 R3 ask; defense-in-depth on production writes. |
+| [#23](https://github.com/Anguijm/city-atlas-service/issues/23) | Lead-architect rule: 'any reviewer ≤4 → BLOCK' fires on no-impact scoring | One-line `.harness/council/lead-architect.md` edit. Pair with #16. |
 
 ## In flight (branches not yet merged)
 
-_None._ Working tree clean as of 2026-04-26.
+- **`session-close/2026-04-26-pt2`** — this very session's close docs (this BACKLOG.md update, learnings.md append, SESSION_HANDOFF.md refresh, etc.). Will become PR #24 when pushed.
 
 ## Recently closed
 
 - **#11** — Scraper refinement (Atlas Obscura URL pattern, Infatuation finder, retire SBL). Closed by PR #15 (`1f04365`) on 2026-04-26.
 - **#10** — Scraper malfunction on parked metros. Closed in prior session via `f627d83`.
 - **PR #18** — CLAUDE.md round-N drift doctrine + submitter-response format. Merged `4522361`.
+- **PR #19** — CLAUDE.md honest doctrine + reality reconciliation (DB name, schema package, task collections). Admin-merged `c9f8985` after R1 PR-comment remediation fulfilled.
+- **PR #20** — `.github/workflows/branch-guard.yml` post-hoc detector for direct pushes. Admin-merged `f3a9f5e` after R3 same-surface flip; legitimate ask filed as #21.
+- **PR #22** — Branch-guard `pull-requests: read` permission fix (one-liner unblocking the workflow). Admin-merged `942dc50` after R2 scoring-rule misfire; root cause filed as #23.

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -11,14 +11,18 @@
 
 ## Start here next session
 
-- **`main` HEAD:** `4522361` (PR #18 — CLAUDE.md round-N drift doctrine)
-- **Last substantive merge:** `1f04365` (PR #15 — scraper refinement: Atlas Obscura overrides, Infatuation finder, Spotted by Locals retired)
-- **Open PRs:** none. Working tree clean.
+- **`main` HEAD:** `942dc50` (PR #22 — branch-guard permissions one-line fix)
+- **Last substantive merge:** `f3a9f5e` (PR #20 — `.github/workflows/branch-guard.yml`, post-hoc detector for direct pushes to main)
+- **Open PRs:** session-close PR likely #24 if the assistant left it open; otherwise none. Working tree expected clean.
 - **Top-priority next actions, in order:**
-  1. **Issue #16 — extend `.harness/scripts/council.py` to fetch prior council comment + submitter response and prepend to round-N persona prompts.** ~50–80 lines. Highest leverage on the bench because every substantive PR currently pays the override-paperwork tax for synthesizer drift. CLAUDE.md doctrine (PR #18) makes the burden predictable; this fix removes the burden.
-  2. **Honolulu recovery — single command + re-ingest.** `mv data/research-output/failed/honolulu.json data/research-output/honolulu.json` then `python src/pipeline/research_city.py --city honolulu --ingest-only --enrich`. Closes the production-ingest gap from the prior session (15/16 → 16/16).
-  3. **Issue #12 — CI smoke-test on entry-point scripts.** Three porting-miss bugs landed in prior sessions; pattern is well-established. File and design before the next porting cycle introduces a fourth.
-- **Blockers:** none. CI failures on `validate` and `watch` are pre-existing tech debt unrelated to recent diffs (typecheck errors in test files, OIDC token config in pr-watch); not introduced by any of this session's PRs.
+  1. **Council-tightening sprint: #16 + #23 together.** #16 extends `.harness/scripts/council.py` to fetch prior council comment + submitter response and prepend to round-N persona prompts (~50–80 lines). #23 tightens the lead-architect rule so `score ≤4` requires a non-empty concern body before triggering BLOCK (one-line edit to `.harness/council/lead-architect.md` plus possibly persona-prompt recalibration). Both are load-bearing — every substantive PR this session burned 1–3 wasted council rounds for non-substantive reasons that these two fixes specifically address.
+  2. **Honolulu recovery** — single command + re-ingest. `mv data/research-output/failed/honolulu.json data/research-output/honolulu.json` then `python src/pipeline/research_city.py --city honolulu --ingest-only --enrich`. Closes 15/16 → 16/16.
+  3. **Issue #21 — automate branch-guard preflight inside pipeline entry points.** Round-3 council ask on PR #20, deferred. Defense-in-depth on production writes.
+  4. **Issue #12 — CI smoke-test on entry-point scripts.** Three porting-miss bugs landed across prior sessions; pattern is well-established.
+- **Blockers:** none. CI failures on `validate` and `watch` are pre-existing tech debt unrelated to any session diff. The new `branch-guard` check passes on every legitimate PR merge (verified end-to-end on `942dc50`).
+- **Doctrine reminders for next session:**
+  - **All changes to main MUST go through PRs.** Direct push will fail the `branch-guard` workflow post-hoc and leave a paper trail in the Actions tab. The session-close prompt does NOT specify the merge mechanism — the doctrine + workflow do.
+  - Database name is `urbanexplorer`, NOT `travel-cities`. Schemas are at `src/schemas/cityAtlas.ts`, NOT a published npm package. Tasks live nested under cities + flat in `vibe_tasks`, NOT in `tasks_rt`/`tasks_ue`. (CLAUDE.md "Firestore discipline" section has the full rundown.)
 
 ## What this repo is
 


### PR DESCRIPTION
## Summary

End-of-session housekeeping after a turn that merged **3 PRs** (#19 doctrine + reconciliation, #20 branch-guard workflow, #22 permissions one-liner) and filed **2 issues** (#21 automate branch-guard preflight, #23 lead-architect rule misfire). All admin-overridden with rationale per the round-N drift doctrine.

## Files changed
- \`.harness/learnings.md\` — new KEEP/IMPROVE/INSIGHT/COUNCIL block; covers doctrine reconciliation, branch-guard saga, council drift second/third instance, and the two filed structural-fix issues.
- \`SESSION_HANDOFF.md\` — start-here block refreshed: main HEAD \`942dc50\`, next actions promote the council-tightening sprint (#16 + #23 together), doctrine reminders now include the branch-guard + urbanexplorer-DB reality.
- \`BACKLOG.md\` — Now-tier elevates #16+#23 as a paired sprint; #21 added; #23 added; In-flight notes this PR; Recently closed gets PR #19/#20/#22.

## Audit done
No code changes. \`grep\` for \`travel-cities\` / \`@travel/city-atlas-types\` / \`tasks_rt\` / \`tasks_ue\` confirms remaining hits are all intentional doctrine wording in CLAUDE.md / CONTRIBUTING.md / SESSION_HANDOFF.md / persona files explaining what those names refer to (planned-but-not-executed migrations, retired scaffolding, etc.). PR #19 already cleaned the active-fact references.

## Test plan
- [x] Working tree clean before/after.
- [x] All session-close docs (learnings, handoff, backlog, memory) refreshed.
- [x] Going through PR — first session-close in this repo to do so under the new branch-guard regime.
- [ ] Council 🟢 (markdown only; same shape as PR #18, #19).

## Notable

This is the first session-close in this repo to go through a PR rather than direct-commit. Last turn's session-close was \`87af222\` direct-pushed to main — caught by the user, surfaced the doctrine vs workflow gap, and led to PR #19 + #20 closing it. The new flow (CLAUDE.md doctrine + branch-guard workflow) makes direct-push fail post-hoc; the PR path is now the only clean option. Self-test of the new regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)