### PR TITLE
branch-guard: retry commit→PR lookup to absorb GitHub API eventual consistency

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -38,7 +38,28 @@ jobs:
           REPO="${{ github.repository }}"
           echo "Checking commit $SHA on $REPO ..."
 
-          PR_COUNT=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq 'length')
+          # GitHub's commit→PR association endpoint is eventually consistent.
+          # On a freshly-merged PR the lookup can return [] for several seconds
+          # before the index catches up. Retry with bounded backoff (~30s total).
+          # A genuine direct push stays empty across all retries and still fails.
+          PR_JSON=""
+          PR_COUNT=0
+          for ATTEMPT in 1 2 3 4; do
+            PR_JSON=$(gh api "/repos/$REPO/commits/$SHA/pulls")
+            PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+            if [ "$PR_COUNT" -gt 0 ]; then
+              if [ "$ATTEMPT" -gt 1 ]; then
+                echo "PR association resolved on attempt $ATTEMPT."
+              fi
+              break
+            fi
+            if [ "$ATTEMPT" -lt 4 ]; then
+              SLEEP=$((ATTEMPT * 5))
+              echo "Attempt $ATTEMPT: no PR association yet, sleeping ${SLEEP}s..."
+              sleep "$SLEEP"
+            fi
+          done
+
           if [ "$PR_COUNT" -eq 0 ]; then
             echo "::error::Direct push to main detected (commit $SHA has no associated PR)."
             echo "::error::All changes to main must go through a PR per CLAUDE.md doctrine."
@@ -46,12 +67,12 @@ jobs:
             exit 1
           fi
 
-          MERGED_COUNT=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '[.[] | select(.merged_at != null)] | length')
+          MERGED_COUNT=$(echo "$PR_JSON" | jq '[.[] | select(.merged_at != null)] | length')
           if [ "$MERGED_COUNT" -eq 0 ]; then
             echo "::error::Commit $SHA is referenced by PR(s) but none are marked merged."
             echo "::error::This is unexpected on main; investigate manually."
             exit 1
           fi
 
-          PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '[.[] | select(.merged_at != null)][0].number')
+          PR_NUM=$(echo "$PR_JSON" | jq '[.[] | select(.merged_at != null)][0].number')
           echo "✓ Commit $SHA is the merge of PR #$PR_NUM — branch guard passes."


### PR DESCRIPTION
## Summary

- Wrap the `/commits/{sha}/pulls` lookup in a 4-attempt retry loop (5s/10s/15s backoff, ~30s max budget) to absorb GitHub API eventual consistency on freshly-merged PRs.
- Collapse three sequential `gh api` calls into one fetch + local `jq` filters; removes a TOCTOU window where intermediate calls could see different snapshots.
- A genuine direct push returns `[]` across all attempts and still fails the run — semantics preserved.

Closes #25.

## Why

The post-hoc detector landed in PR #20 fired a false-positive on PR #24's own squash-merge commit (`058d123`). The merge happened at `T+0`; the workflow ran at `T+7s`; the API still returned `[]`; re-checking moments later returned PR #24 with `merged_at` populated. Two false positives in three branch-guard runs is a poor signal-to-noise ratio for a doctrine signal.

## Test plan

- [x] Bash syntax check passes (`bash -n` on the extracted run block).
- [x] Logic walkthrough: success path on attempt 1 prints nothing extra; success path on attempt 2+ prints the resolved-on-attempt note; empty across all 4 attempts hits the existing "direct push" failure branch.
- [ ] Empirical: when this PR merges, branch-guard runs on the new merge commit. Pass = the very class of bug this PR fixes.
- [ ] Council 🟢 (or admin-override paperwork if it spirals on a workflow-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)