### PR TITLE
Session close 2026-04-26 (pt4): post-PR-#28 doc refresh

### DIFF
--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -756,3 +756,56 @@ Production data: **honolulu ingested** — parked-metros backlog now **16/16**.
 3. **Honolulu count bump (optional)** — if filling out the 19→typical-metro-count gap matters, run `python src/pipeline/research_city.py --city honolulu --enrich` (no `--ingest-only`) to invoke Phase B's find-new-places pass + re-ingest. Pure additive write under `source: "enrichment-*"`.
 4. **#12 — CI smoke-test on entry-point scripts.** Three-data-points porting-miss bug class. Now compounded by the documented `--ingest-only --enrich` flag-composition gotcha from this turn.
 5. **#17 — unit tests for `geoBoundsFor` + Infatuation HTML fixtures.** Cheap follow-up from PR #15 R2.
+
+---
+
+## 2026-04-26 (pt4) — pt3 docs landed, council drift dataset extended
+
+`main` HEAD: `9d21015` (PR #28 admin-merge). Started this continuation at `95c29ce` (post-PR #27).
+One PR landed: **#28 (`9d21015`)**. No issues filed (no new structural problems uncovered).
+Two PRs total this turn: #27 (✅ R1 🟢) and #28 (🔴 R1 → 🔴 R2 → admin-merge with paperwork).
+
+### KEEP
+
+- **PR #28's "apply legit ask + push + admin-merge with response comment" pattern is the right shape for mixed-verdict councils.** Council R1 BLOCKed with one legit ask (#2: doc warning) + three OOS (#1 pipeline code, #3 prompt-injection #7, #4 UA email #9). Pattern: address #2 in code, argue OOS on the rest in the response comment. R2 came back with same-surface flip on R1 #1 (still asking for pipeline code change in a docs PR) + a partial-credit ask on the doc framing (#4) + a hallucinated UE constraint (#3). Pattern again: address the partial credit, argue OOS on the rest, admin-merge with full paperwork. Total burn: 2 council rounds for a docs PR — high but converged.
+
+- **The submitter-response comment format keeps paying dividends.** Used twice on PR #28 (R1 + R2). Each comment was structured: score-deltas table → status-by-remediation table → "## Argued out-of-scope" section → "## CI failures" section → forward-looking note about the next round expectation. The format made the admin-override paperwork in the merge commit a near-direct restatement of the comment — no fresh writing needed.
+
+- **Cross-checking reviewer claims against the codebase prevents capitulating to hallucinated constraints.** PR #28 R2 product reviewer asserted "UE has a 12-waypoint-per-neighborhood minimum" and downgraded product=9→5 on that basis. Searched CLAUDE.md, schemas, and prior session notes — no such constraint anywhere. Likely reviewer fabrication. Response comment named the uncertainty explicitly ("not documented in CLAUDE.md, schemas, or any artifact I have access to — likely reviewer-hallucinated") rather than auto-promoting honolulu-count-bump to P1 on a fact that may not exist. **Generalization: when a reviewer's BLOCK rests on a consumer-side constraint, verify against the schema contract first; the schema is the contract, not the reviewer's claim.**
+
+### IMPROVE
+
+- **PR #28 R1 cost=1 → R2 cost=10 score-flip on the same diff is the cleanest before/after evidence for #23 yet seen.** R1 cost=1 with body literally saying "Required remediations: None" + "intended, one-time, operator-driven cost, not an automated or recurring one" — pure score noise. R2 cost=10 with similar body content — substantive read. Same diff (R2 added only an unrelated doc-warning commit `af8d797`), same cost reviewer, opposite scores. The cost reviewer changed its own mind by 9 points in the absence of any cost-relevant change. That's not signal — that's noise. This data point should be cited verbatim when implementing #23's `score ≤4 + empty body = no BLOCK` rule. **The R1 → R2 progression on PR #28 is now the canonical "this is what synthesizer drift looks like" exhibit.**
+
+### INSIGHT
+
+- **The "validate" CI check is now a chronic source of false-RED alongside green council.** PR #27, PR #28 both shipped with red `validate` from pre-existing TS typecheck errors in `src/__tests__/build-vibe-cache-*.test.ts`, `src/scrapers/local-sources.ts`, `src/pipeline/qc_cleanup.ts`. None of those files have been touched in any session diff for at least the last six PRs. **Until #12 brings `validate` green, the check has signal-to-noise approaching zero.** Issue #12's design should consider splitting it into "pre-existing baseline" (must remain green) vs "introduced-by-diff" (blocks merge) sub-jobs so the producer-side signal matches the actual delta of each PR.
+
+- **Honolulu's BACKLOG.md DANGER block is now the canonical "decision rule for `--ingest-only` on `failed/` files."** Wrote the operator decision rule in three layers: (1) when it's safe (transient write error, Phase A/B/C succeeded, ingest itself failed), (2) when it's unsafe (Phase C rejected the city), (3) what to do instead (`--enrich` without `--ingest-only` reruns Phase B/C). The reviewer's R2 #4 ask drove this clarification — and the reviewer was correct that R1's warning was insufficient. **Generalization: when a council reviewer says "the warning is not strong enough," that's often a real ask even from a synthesizer that's also producing OOS noise; differentiate "strengthen the legit thing" from "concede the OOS thing."**
+
+- **`gh pr merge --admin --squash` accepts `--subject` and `--body` and uses them verbatim — they're not concatenated with the PR description.** Verified on PR #28: the merge commit message is exactly the multi-paragraph rationale passed via `--body`, with the `--subject` as the squash subject. This is the right tool when admin-merge paperwork needs to land in the commit log (vs only in PR comments). Useful for any future override.
+
+### COUNCIL
+
+- **PR #27 (branch-guard retry-with-backoff): R1 🟢 CLEAR.** Scores 10/10/10/10/6/10. Synthesizer correctly read product=6 with neutral-impact body as "no concern." Squash-merge round 1. **Net burn: 1 round, ~7 Gemini calls.**
+
+- **PR #28 (pt3 session-close docs): R1 🔴 BLOCK → R2 🔴 BLOCK → admin-merge.**
+  - R1 scores: 10/10/3/1/9/4. Three OOS asks (#7-prompt-inj, #9-UA-email, pipeline code in docs PR) + one legit (doc warning). Cost=1 with empty body = #23 noise pattern.
+  - R2 scores: 10/10/4/10/5/6. Score deltas: cost +9, security +2, bugs +1, product −4. NEW remediations: same-surface flip on pipeline code (R2 #1 ↔ R1 #1), out-of-band UE coordination (R2 #2), hallucinated UE constraint (R2 #3), legit partial-credit on doc framing (R2 #4).
+  - **Admin-merged with paperwork** per round-N drift doctrine. Architecture reviewer 10/10 with "improves operational safety, no remediations" is the closest read of "is this PR shippable as-is." Lead-architect overweighted bugs=4 + product=5 against architecture=10 + cost=10.
+  - **Net burn: 2 rounds, ~14 Gemini calls** for a 4-file markdown diff. Without #16 + #23 the next docs PR will pay the same tax.
+
+### Production state at session close (pt4)
+- `main`: `9d21015` (PR #28).
+- Open PRs: **session-close PR pending** (this very commit).
+- Open issues: **9 total** — #5, #6, #7, #8, #9, #12, #14, #16, #17, #21, #23. Unchanged from pt3.
+- Production Firestore unchanged from pt3: 16/16 parked metros live (4 verified, 12 degraded). Geneva + lisbon still parked, london still missing from manifest.
+- Branch-guard ✓ on `9d21015` (the merge commit of pt3 docs). Second consecutive merge to validate the retry-with-backoff fix; no false-RED observed since PR #27 landed.
+
+### Carryover for next session (re-prioritized)
+
+1. **#23 — lead-architect score-rule fix.** Now has the cleanest evidence yet: PR #28 R1 cost=1 → R2 cost=10 with same diff. One-line edit to `.harness/council/lead-architect.md` to require non-empty body before `score ≤4` triggers BLOCK. Pair with #16.
+2. **#16 — cross-round memory in council prompts.** PR #28 R2 surfaced same-surface flips on R1 #1 (pipeline code change). Without round-N reading R1's response comment, this drift will keep happening. ~50–80 lines in `.harness/scripts/council.py`.
+3. **#21 — branch-guard preflight automation in pipeline entry points.** PR #27's retry pattern is the copy-pasteable template. Helper called from each `--ingest`/`--ingest-only` entry point. Bonus: the same helper is the natural place to add a Phase-C-bypass guard for `--ingest-only` against `data/research-output/failed/` files (per PR #28 R2 #1 deferred ask).
+4. **#12 — CI smoke-test on entry-point scripts.** Compounded by the `--ingest-only` flag-composition gotcha (which doesn't trip any existing CI check). Could also fold in the "split `validate` into baseline-vs-diff" idea documented in pt4 INSIGHT.
+5. **#17 — unit tests for `geoBoundsFor` + Infatuation HTML fixtures.** Cheap follow-up from PR #15 R2.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,7 @@
 > For long-form session learnings see `.harness/learnings.md`.
 > For start-here-next-session block see `SESSION_HANDOFF.md`.
 >
-> Last refreshed: 2026-04-26 (pt3).
+> Last refreshed: 2026-04-26 (pt4).
 
 ## Now (this week)
 
@@ -49,11 +49,12 @@
 
 ## In flight (branches not yet merged)
 
-- **`docs/session-close-2026-04-26-pt3`** — this very session's close docs (this BACKLOG.md update, learnings.md append, SESSION_HANDOFF.md refresh).
+- **`docs/session-close-2026-04-26-pt4`** — pt4 session-close docs (this BACKLOG.md update, learnings.md pt4 append, SESSION_HANDOFF.md HEAD bump, MEMORY.md refresh).
 
 ## Recently closed
 
-- **#25** — Branch-guard eventual-consistency false-positive. Closed by PR #27 (`95c29ce`) — 4-attempt retry with 5s/10s/15s backoff over the `gh api /commits/{sha}/pulls` lookup. Empirically validated: branch-guard ✓ on PR #27's own merge commit (the very class of bug the PR fixes).
+- **PR #28** — pt3 session-close docs (branch-guard retry fix + Honolulu recovery docs). Admin-merged `9d21015` after R1 🔴 → R2 🔴. Score deltas R1→R2: cost +9, security +2, bugs +1, product −4. R1 cost=1 with empty body → R2 cost=10 with substantive body on the same diff = canonical #23 score-noise evidence. Architecture reviewer 10/10 with "improves operational safety, no remediations" both rounds. Override paperwork in the merge commit + R1/R2 PR comments.
+- **#25** — Branch-guard eventual-consistency false-positive. Closed by PR #27 (`95c29ce`) — 4-attempt retry with 5s/10s/15s backoff over the `gh api /commits/{sha}/pulls` lookup. Empirically validated: branch-guard ✓ on PR #27's own merge commit (the very class of bug the PR fixes), and again on PR #28's merge commit (`9d21015`).
 - **Honolulu (no issue)** — Parked-metros backlog now **16/16**. Ingested via `enrich_ingest.ts` additive path: 5 neighborhoods / 19 waypoints / 100 tasks / `coverageTier: metro` / `quality_status: degraded` written to `urbanexplorer`.
   - **⚠ DANGER — this is a one-off recovery for a TRANSIENT WRITE ERROR, not a general recipe for any failed city.** Honolulu's Phase A/B/C ran *successfully* and produced a `quality_status: degraded` JSON. The original failure was a **transient write error** at the Firestore-ingest step — specifically the pre-`1f173b7` `--ingest-only` flag-routing bug (which dropped `--enrich` and routed through the strict baseline path that rejects degraded JSONs). That bug has been fixed; ingesting the existing JSON additively was therefore safe and equivalent to having ingested it correctly the first time.
   - **DO NOT use `--ingest-only --enrich` for any city that landed in `data/research-output/failed/` because Phase C rejected its content** (coordinate drift, hallucinated POIs, semantic-audit failure, etc.). Phase C is the load-bearing semantic gate and `--ingest-only` skips it; running this recipe on a Phase-C-rejected JSON would push known-bad data to production Firestore. The correct procedure for those cases is `python src/pipeline/research_city.py --city <X> --enrich` (no `--ingest-only`), which re-runs Phase B (find new places) and Phase C (semantic audit) before any Firestore write. If Phase C rejects again, the city stays parked and the recipe is NOT a way around that.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Batch data pipeline that builds the shared city atlas consumed by **Urban Explor
 
 ## Status
 
-Pipeline operational and producing live Firestore data. Extracted from [urban-explorer](https://github.com/Anguijm/urban-explorer) in April 2026 (PR #2). End-to-end validated through real Gemini output on 2026-04-25 — 15 of the 19 originally-parked metro cities now ingested as `source: "enrichment-*"` documents in the `urbanexplorer` named database; 4 of those 15 are `quality_status: verified` (the first verified data ever produced from this repo). Honolulu pending one-step recovery (16/16); geneva + lisbon are English-source edge cases. Per-source scraper refinement landed in PR #15 (Atlas Obscura overrides, Infatuation finder, Spotted by Locals retired). See `SESSION_HANDOFF.md` for the runbook + `BACKLOG.md` for active priorities.
+Pipeline operational and producing live Firestore data. Extracted from [urban-explorer](https://github.com/Anguijm/urban-explorer) in April 2026 (PR #2). End-to-end validated through real Gemini output on 2026-04-25 — **16 of the 19 originally-parked metro cities now ingested** (honolulu landed 2026-04-26 pt3 via additive `enrich_ingest.ts` path) as `source: "enrichment-*"` documents in the `urbanexplorer` named database; 4 of those 16 are `quality_status: verified` (the first verified data ever produced from this repo); geneva + lisbon remain English-source edge cases; london is mysteriously absent from the manifest. Per-source scraper refinement landed in PR #15 (Atlas Obscura overrides, Infatuation finder, Spotted by Locals retired). Branch-guard (PR #20) detects direct pushes to `main` post-hoc; PR #27 added retry-with-backoff for GitHub API eventual consistency. See `SESSION_HANDOFF.md` for the runbook + `BACKLOG.md` for active priorities.
 
 ## Governance
 
@@ -59,8 +59,10 @@ Tracked as GitHub issues:
 - **#14** — Admin web interface for POI find/add/edit (paste URL or info directly)
 - **#16** — Council infrastructure: pass prior remediations + submitter response into round-N prompt to prevent synthesizer drift
 - **#17** — Unit tests for `geoBoundsFor` + Infatuation HTML fixtures
+- **#21** — Automate branch-guard preflight inside pipeline entry points (defense-in-depth for production writes)
+- **#23** — Lead-architect rule: `score ≤4` should require non-empty body before triggering BLOCK (eliminates score-noise false-blocks)
 
-(#11 closed by PR #15. #10 closed in prior session via `f627d83`.)
+(#11 closed by PR #15. #10 closed in prior session via `f627d83`. #25 closed by PR #27.)
 
 The pipeline is currently producing data despite all of these — they're improvements, not blockers. Priority guidance lives in `BACKLOG.md` (active) and `SESSION_HANDOFF.md` (start-here block).
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 # Session Handoff — city-atlas-service
 
-> Living document. Last refreshed 2026-04-26 (pt3) at end-of-session. Edit in
+> Living document. Last refreshed 2026-04-26 (pt4) at end-of-session. Edit in
 > place rather than appending date-stamped blocks — this is the "what would
 > you want to know on day one" index, not a changelog.
 >
@@ -11,18 +11,20 @@
 
 ## Start here next session
 
-- **`main` HEAD:** `95c29ce` (PR #27 — branch-guard retry-with-backoff for API eventual consistency)
-- **Last substantive merge:** same — `95c29ce`. Production data also moved this session: **honolulu ingested**, parked-metros backlog now **16/16** in the `urbanexplorer` named database.
+- **`main` HEAD:** `9d21015` (PR #28 — pt3 session-close docs, admin-merged after 2-round council drift)
+- **Last substantive code merge:** `95c29ce` (PR #27 — branch-guard retry-with-backoff, 🟢 R1)
+- **Production state:** **16/16 parked metros live** in the `urbanexplorer` named Firestore database (4 verified, 12 degraded). Honolulu landed pt3 via additive `enrich_ingest.ts` path. No outstanding pipeline runs.
 - **Open PRs:** session-close PR pending if the assistant left it open. Working tree expected clean otherwise.
 - **Top-priority next actions, in order:**
-  1. **Council-tightening sprint: #16 + #23 together.** #16 extends `.harness/scripts/council.py` to fetch prior council comment + submitter response and prepend to round-N persona prompts (~50–80 lines). #23 tightens the lead-architect rule so `score ≤4` requires a non-empty concern body before triggering BLOCK (one-line edit to `.harness/council/lead-architect.md` plus possibly persona-prompt recalibration). PR #27's R1 🟢 CLEAR with `product: 6` shows the synthesizer can read this case correctly — but PR #22 didn't, so the rule needs to be explicit, not implicit.
-  2. **Issue #21 — automate branch-guard preflight inside pipeline entry points.** Round-3 council ask on PR #20, deferred. Defense-in-depth on production writes. **PR #27's retry pattern (4-attempt loop, 5s/10s/15s backoff over `gh api /commits/{sha}/pulls`) is the copy-pasteable template** for the eventual-consistency handling this helper needs.
-  3. **Issue #12 — CI smoke-test on entry-point scripts.** Three porting-miss bugs across prior sessions; pattern is well-established. Now compounded by the `--ingest-only --enrich` flag-composition gotcha documented in pt3 learnings (additive ingest, no Phase B re-run).
+  1. **Council-tightening sprint: #23 + #16 together.** PR #28 produced the cleanest before/after evidence yet for #23: R1 cost=1 (body literally "Required remediations: None") → R2 cost=10 (substantive body) on the same diff — pure score noise. One-line edit to `.harness/council/lead-architect.md` to require non-empty body before `score ≤4` triggers BLOCK. #16 extends `.harness/scripts/council.py` to fetch prior council comment + submitter response and prepend to round-N persona prompts (~50–80 lines), closing the cross-round memory gap that produced PR #28 R2's same-surface flip on R1 #1.
+  2. **Issue #21 — automate branch-guard preflight inside pipeline entry points.** Round-3 council ask on PR #20, deferred. **PR #27's retry pattern (4-attempt loop, 5s/10s/15s backoff over `gh api /commits/{sha}/pulls`) is the copy-pasteable template.** The same helper is the natural place to add a Phase-C-bypass guard for `--ingest-only` against `data/research-output/failed/` files (per PR #28 R2 #1 deferred ask).
+  3. **Issue #12 — CI smoke-test on entry-point scripts.** Three porting-miss bugs across prior sessions, plus the `--ingest-only --enrich` flag-composition gotcha (additive ingest, no Phase B re-run). Worth folding in a "split `validate` into baseline-vs-diff" sub-design — the chronic red-validate-next-to-green-council noise is hurting PR signal-to-noise.
   4. **Issue #17 — unit tests for `geoBoundsFor` + Infatuation HTML fixtures.** Cheap follow-up from PR #15 R2.
-- **Blockers:** none. CI failures on `validate` and `watch` remain pre-existing tech debt unrelated to any session diff. The `branch-guard` check now passes reliably on every legitimate PR merge (validated end-to-end on `95c29ce`'s own merge commit, which is the very class of bug PR #27 fixes).
+- **Blockers:** none. CI failures on `validate` and `watch` remain pre-existing tech debt unrelated to any session diff. The `branch-guard` check passes on every legitimate PR merge (validated on `95c29ce` and `9d21015` consecutively after PR #27).
 - **Doctrine reminders for next session:**
   - **All changes to main MUST go through PRs.** Direct push fails the `branch-guard` workflow post-hoc and leaves a paper trail in the Actions tab. As of PR #27 the workflow self-heals over GitHub API eventual consistency — false-positive failures on freshly-merged commits are gone.
   - **Branch-guard preflight before pipeline writes.** Run `gh run list --workflow branch-guard.yml --branch main --limit 1 --json conclusion --jq '.[0].conclusion'` and confirm `success` before any `--ingest`/`--ingest-only` invocation. The retry-with-backoff fix means false RED is no longer expected; if you see RED on HEAD, treat it as real and investigate.
+  - **`--ingest-only` skips Phase C; do NOT run it on Phase-C-rejected JSON in `data/research-output/failed/`.** Honolulu's pt3 recovery was safe ONLY because its Phase A/B/C succeeded and the failure was at the Firestore-write step (pre-`1f173b7` flag-routing bug). Cities parked in `failed/` for Phase C reasons must use `python src/pipeline/research_city.py --city <X> --enrich` (no `--ingest-only`) so Phase B/C run. See BACKLOG.md "Recently closed > Honolulu" for the full operator decision rule.
   - Database name is `urbanexplorer`, NOT `travel-cities`. Schemas are at `src/schemas/cityAtlas.ts`, NOT a published npm package. Tasks live nested under cities + flat in `vibe_tasks`, NOT in `tasks_rt`/`tasks_ue`. (CLAUDE.md "Firestore discipline" section has the full rundown.)
 
 ## What this repo is
@@ -46,16 +48,16 @@ needed from this repo until then.
 
 ## What's in main right now
 
-`main` = `95c29ce` at the end of the 2026-04-26 (pt3) session. Recent history:
+`main` = `9d21015` at the end of the 2026-04-26 (pt4) session. Recent history:
 
 ```
+9d21015 Session close 2026-04-26 (pt3): branch-guard retry fix + Honolulu recovery docs (#28)
 95c29ce branch-guard: retry commit→PR lookup to absorb GitHub API eventual consistency (#27)
 058d123 Session close 2026-04-26 (continued): docs refresh after PR #19/#20/#22 (#24)
 942dc50 Fix branch-guard: add pull-requests: read permission (#22)
 f3a9f5e Branch Guard workflow: post-hoc detect direct pushes to main (#20)
 c9f8985 CLAUDE.md: honest doctrine + reconcile docs with code reality (#19)
 4522361 CLAUDE.md: codify round-N drift doctrine + submitter response format (#18)
-1f04365 Refine scrapers per issue #11: Atlas Obscura overrides, Infatuation finder, retire SBL (#15)
 ```
 
 Layout:

--- a/docs/DATA_COVERAGE_REPORT.md
+++ b/docs/DATA_COVERAGE_REPORT.md
@@ -15,6 +15,8 @@
 > - **Honolulu** is recoverable in one step (Gemini-variance casualty of the pre-fix `--ingest-only` bug; data intact in `data/research-output/failed/`). See `SESSION_HANDOFF.md` "Now" tier.
 > - **Geneva, Lisbon, London** are the unresolved tail. Geneva + Lisbon: legitimate English-source-coverage edge cases — Phase B fabricates over the gap and Phase C correctly rejects at >25%. London: present in `configs/global_city_cache.json` but absent from `manifest.cities`, mystery TBD.
 > - The **5 legitimate village-tier failures** described in §1 (`fairbanks`, `kahului`, `marfa`, `little-rock`, `portland-me`) are still legitimately limited by real POI density at small radii. Not affected by the parked-19 arc.
+>
+> **Status update 2026-04-26 (pt3) — Honolulu ingested, parked-metros backlog now 16/16:** The recoverable honolulu file moved from `data/research-output/failed/honolulu.json` to `data/research-output/honolulu.json` and was ingested via the additive `enrich_ingest.ts` path with `--ingest-only --enrich`: 5 neighborhoods / 19 waypoints / 100 tasks / `coverageTier: metro` / `quality_status: degraded` written to `urbanexplorer`. **This recipe is a one-off for transient write errors — do NOT generalize it to cities parked in `failed/` for Phase C reasons** (see `BACKLOG.md` "Recently closed > Honolulu" for the operator decision rule). Geneva + Lisbon still parked as English-source edge cases; London still missing from manifest.
 
 ---
 


### PR DESCRIPTION
## Summary

Cold-start surface refresh after PR #27 (branch-guard retry fix, 🟢) and PR #28 (pt3 session-close docs, admin-merged after R1→R2 council drift) landed in `main` (`9d21015`).

- **`.harness/learnings.md`** — pt4 KEEP / IMPROVE / INSIGHT / COUNCIL block. Documents PR #28 R1 cost=1 → R2 cost=10 on the same diff as the canonical #23 score-noise exhibit, the submitter-response-comment pattern's continued payoff (used twice on PR #28), and `gh pr merge --admin --squash --subject/--body` semantics for landing override paperwork in the commit log.
- **`BACKLOG.md`** — HEAD bumped, PR #28 added to "Recently closed" with full score-delta paperwork, In-flight rotated to this PR's branch.
- **`README.md`** — 15→16 metros (honolulu landed pt3); added #21 and #23 to "Open work"; noted #25 closed by PR #27.
- **`SESSION_HANDOFF.md`** — "Start here next session" block bumped to `9d21015`; reordered next actions around the council-tightening sprint (#23 + #16) leveraging PR #28's evidence; added a doctrine reminder that `--ingest-only` must never run on Phase-C-rejected JSON.
- **`docs/DATA_COVERAGE_REPORT.md`** — appended a 2026-04-26 (pt3) status update note about honolulu's ingest and the operator decision rule for the `--ingest-only` recipe.
- **Memory** (out-of-tree, in `~/.claude/projects/.../memory/`) — `project_parked_cities.md` (15→16, honolulu DONE), `feedback_council_drift.md` (PR #28 cost-noise exhibit added), `MEMORY.md` index descriptions refreshed.

CLAUDE.md: audited, no updates needed (doctrine doc; the existing three admin-override examples illustrate the categories).

## Why

The session-close prompt requires keeping the cold-start surface in sync with `main` so the next session can boot from accurate facts. PR #27 landed substantive code; PR #28 admin-merged docs after a notable round-N drift saga. Both the "what's true" and "what to do next" surfaces need to reflect that.

## Test plan

- [x] `git status` clean before commit; only the five expected paths in the diff.
- [x] `BACKLOG.md` open-issues table reconciled with `gh issue list --state open` (no change since pt3).
- [x] `SESSION_HANDOFF.md` HEAD line + recent-history block reflect current `git log`.
- [x] `README.md` "Open work" list mirrors `BACKLOG.md`'s open-issues table.
- [ ] Council 🟢 (markdown-only diff; expected clean — but per pt4 INSIGHT this kind of PR still triggers cost/security score-noise pre-#23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)