### PR TITLE
Adopt harness-cli V0.3.2 (T1/T2 council + model-retirement fix)

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -18,7 +18,7 @@ env:
   # HARNESS_SHA must be updated alongside (the immutable commit pin used
   # for the actual checkout — supply-chain guard against tag force-push).
   HARNESS_VERSION: V0.3.2
-  HARNESS_SHA: ce329581edbeeee54457244e1d8801ce83ef97f0
+  HARNESS_SHA: 644cae64ab50e691b73f19446b25d32874dcdfe2
 
 on:
   schedule:

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -17,8 +17,8 @@ env:
   # Bump deliberately; see https://github.com/Anguijm/harness-cli/releases.
   # HARNESS_SHA must be updated alongside (the immutable commit pin used
   # for the actual checkout — supply-chain guard against tag force-push).
-  HARNESS_VERSION: V0.2.1
-  HARNESS_SHA: c9a5bedea63afbc4e94b3f0625de32836ccda0c5
+  HARNESS_VERSION: V0.3.2
+  HARNESS_SHA: ce329581edbeeee54457244e1d8801ce83ef97f0
 
 on:
   schedule:


### PR DESCRIPTION
Bumps the drift-check pin `V0.2.1` → **V0.3.2** (`HARNESS_SHA` → `ce329581`).

Adopts the canonical council with **T1 continuous logprob scoring** + **T2 repeated-evaluation (K)**, plus the gemini-2.5-pro retirement fix. The weekly drift-check now compares this repo against V0.3.2. One-line env change in `.github/workflows/drift-check.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpreB8GLru72n1UXxRaUb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpreB8GLru72n1UXxRaUb3)_